### PR TITLE
Fix backend VRAM setup and frontend build

### DIFF
--- a/backend/service.py
+++ b/backend/service.py
@@ -68,6 +68,7 @@ try:
         controlnet=cnet,
         torch_dtype=torch.float16
     ).to(device)
+    sd.enable_xformers_memory_efficient_attention()
     sd.enable_model_cpu_offload()  # save VRAM
 
     # 4) Single-image-to-mesh model

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BACKEND_ENDPOINT=http://localhost:5000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+!.env.local
 .env
 
 # vercel

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,5 +1,6 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };
-
-export default config;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,15 +1,10 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;
   --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/frontend/src/components/ModelPreview.tsx
+++ b/frontend/src/components/ModelPreview.tsx
@@ -11,7 +11,7 @@ export default function ModelPreview({ objB64 }: ModelPreviewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<THREE.Scene | null>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
-  const controlsRef = useRef<OrbitControls | null>(null);
+  const controlsRef = useRef<any>(null);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -58,7 +58,7 @@ export default function ModelPreview({ objB64 }: ModelPreviewProps) {
 
     loader.load(
       objUrl,
-      (object) => {
+      (object: THREE.Object3D) => {
         // Center the model
         const box = new THREE.Box3().setFromObject(object);
         const center = box.getCenter(new THREE.Vector3());
@@ -74,7 +74,7 @@ export default function ModelPreview({ objB64 }: ModelPreviewProps) {
         URL.revokeObjectURL(objUrl);
       },
       undefined,
-      (error) => {
+      (error: any) => {
         console.error('Error loading OBJ:', error);
         URL.revokeObjectURL(objUrl);
       }

--- a/frontend/src/types/three-extras.d.ts
+++ b/frontend/src/types/three-extras.d.ts
@@ -1,0 +1,2 @@
+declare module 'three/examples/jsm/loaders/OBJLoader';
+declare module 'three/examples/jsm/controls/OrbitControls';

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.{ts,tsx}", "./src/**/*.{js,jsx}", "./src/**/*.{html}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- tune backend SD pipeline to use xformers with CPU offload
- enable local env var for frontend API endpoint
- fix Tailwind/PostCSS config and global styles
- adjust ModelPreview types and add `three` module stubs
- provide Tailwind config file

## Testing
- `python test_service.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e820000b88332b0e1b58ec2830cd1